### PR TITLE
chore(MPR-2141): add jira-automation workflow

### DIFF
--- a/.github/workflows/jira-automation.yml
+++ b/.github/workflows/jira-automation.yml
@@ -1,0 +1,31 @@
+name: Notify Jira on pull request events
+on:
+  pull_request:
+    types: [review_requested]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  notify-jira-on-review-requested:
+    if: github.event_name == 'pull_request' && github.event.action == 'review_requested'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call Jira webhook
+        run: |
+          curl -X POST \
+            -H "Content-Type: application/json" \
+            -H "X-Automation-Webhook-Token: ${{ secrets.JIRA_WEBHOOK_SECRET }}" \
+            --data-binary @"${GITHUB_EVENT_PATH}" \
+            "https://api-private.atlassian.com/automation/webhooks/jira/a/bf762931-f0d0-4d3a-b3b4-969cf2396345/01995756-8f78-777e-854f-8c191a4f36f0"
+
+  notify-jira-on-pr-approved:
+    if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call Jira webhook
+        run: |
+          curl -X POST \
+            -H "Content-Type: application/json" \
+            -H "X-Automation-Webhook-Token: ${{ secrets.JIRA_WEBHOOK_SECRET_2 }}" \
+            --data-binary @"${GITHUB_EVENT_PATH}" \
+            "https://api-private.atlassian.com/automation/webhooks/jira/a/bf762931-f0d0-4d3a-b3b4-969cf2396345/0199b922-8d64-7339-8c20-6253354c51fc"


### PR DESCRIPTION
Adds GitHub Actions workflow to notify Jira when PRs are review-requested or approved. This enables automatic Jira status transitions based on PR activity, keeping ticket status in sync with the development workflow.

[MPR-2141](https://mapitiot.atlassian.net/browse/MPR-2141)

[MPR-2141]: https://mapitiot.atlassian.net/browse/MPR-2141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ