### PR TITLE
chore(MPR-2142): add claude-code-review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,80 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+
+jobs:
+  claude-review:
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Please review this pull request and provide feedback on the following when applicable:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Performance considerations
+            - Security concerns
+            - Test coverage
+            Skip any section that is not applicable or do not have any suggested, actionable changes.
+
+            IMPORTANT: Be concise and avoid redundant and repetitive comments.
+            Limit reviews to 120 lines or less.
+
+            If space allows, you may end your comment with a list of up to 5 positive points and a single
+            overall star rating from 1-5.
+
+            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+
+            IMPORTANT: Before posting your review, hide any previous PR review comments from this bot by:
+            1. List all comments on the PR using: `gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments`
+            2. For each comment from @claude (filter by user.login == "claude"), get its node_id
+            3. Hide each comment using the GraphQL API:
+               ```
+               gh api graphql -f query='
+                 mutation {
+                   minimizeComment(input: {
+                     subjectId: "NODE_ID_HERE"
+                     classifier: OUTDATED
+                   }) {
+                     minimizedComment {
+                       isMinimized
+                       minimizedReason
+                     }
+                   }
+                 }'
+               ```
+            4. After hiding old comments, post your new review using: `gh pr comment ${{ github.event.pull_request.number }} --body "YOUR_REVIEW_HERE"`
+
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh api:*)"'


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically runs Claude Code to review pull requests when they are opened or updated. This enables AI-assisted code reviews for the vue-pdf repository.

[MPR-2142](https://mapitiot.atlassian.net/browse/MPR-2142)

[MPR-2142]: https://mapitiot.atlassian.net/browse/MPR-2142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ